### PR TITLE
feat: rebrand from Obsidian-specific to generic ChatGPT to Markdown tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ChatGPT to Obsidian Converter
+# ChatGPT to Markdown Converter
 
-Convert your ChatGPT conversation exports into Obsidian-friendly Markdown files with intelligent duplicate detection and clean formatting. Available as both a Python command-line tool and a modern web interface.
+Convert your ChatGPT conversation exports into clean Markdown files with intelligent duplicate detection and proper formatting. Available as both a Python command-line tool and a modern web interface.
 
 ## 🎯 Features
 
@@ -8,7 +8,7 @@ Convert your ChatGPT conversation exports into Obsidian-friendly Markdown files 
 - **🐍 Python CLI**: Command-line tool for batch processing and automation
 - **🧠 Smart Duplicate Detection**: Automatically skips conversations already imported based on conversation ID
 - **✨ Clean Markdown Formatting**: Properly formats conversations with clear author attribution
-- **📁 Obsidian-Friendly**: Generates files with metadata and structure optimized for Obsidian
+- **📁 Well-Structured**: Generates files with clean metadata and proper formatting
 - **🔒 Safe Filenames**: Automatically slugifies titles and handles special characters
 - **📅 Chronological Order**: Files are created oldest-first to match conversation timeline
 - **⚡ Vercel Deployment**: Deploy your own instance to Vercel with one click
@@ -33,7 +33,7 @@ Convert your ChatGPT conversation exports into Obsidian-friendly Markdown files 
 3. **Upload and Convert**:
    - Export your ChatGPT conversations (Settings → Data Controls → Export Data)
    - Drag and drop `conversations.json` into the web interface
-   - Choose your Obsidian vault folder
+   - Choose your destination folder
    - Files are saved directly to the folder you select (no subfolders created)
 
 ### Option 2: Python CLI
@@ -73,7 +73,7 @@ Files are saved directly to your selected folder:
 ```
 YourSelectedFolder/
 ├── Python Best Practices.md
-├── Obsidian Workflow.md
+├── Markdown Best Practices.md
 └── Machine Learning Intro.md
 ```
 
@@ -82,7 +82,7 @@ Creates organized output in ChatGPT directory:
 ```
 ChatGPT/
 ├── Python Best Practices.md
-├── Obsidian Workflow.md
+├── Markdown Best Practices.md
 └── Machine Learning Intro.md
 ```
 

--- a/chatgpt_converter.py
+++ b/chatgpt_converter.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-ChatGPT to Obsidian Converter
+ChatGPT to Markdown Converter
 
-Converts ChatGPT conversation exports (conversations.json) into Obsidian-friendly
+Converts ChatGPT conversation exports (conversations.json) into clean
 Markdown files, with intelligent duplicate detection and clean formatting.
 """
 
@@ -126,7 +126,7 @@ def convert_conversation_to_markdown(conversation: Dict) -> str:
     # Extract and format messages
     messages = extract_messages(mapping)
     
-    # Build Markdown content with Obsidian-optimized structure
+            # Build Markdown content with clean structure
     # Format timestamp as YYYY-MM-DD, HH:mm:ss for consistency
     timestamp = datetime.fromtimestamp(create_time)
     formatted_timestamp = timestamp.strftime('%Y-%m-%d, %H:%M:%S')
@@ -142,7 +142,7 @@ def convert_conversation_to_markdown(conversation: Dict) -> str:
         author = message['author']
         text = message['content']
         
-        # Format author name with clean Obsidian styling
+                    # Format author name with clean styling
         author_display = "**🧑‍💬 User**" if author == "user" else "**🤖 Assistant**"
         
         content_lines.append(author_display)

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>VaultGPT - ChatGPT to Obsidian Converter</title>
-    <meta name="description" content="Convert your ChatGPT conversations to Obsidian-friendly Markdown files">
+    <title>ChatGPT to Markdown Converter</title>
+    <meta name="description" content="Convert your ChatGPT conversations to clean Markdown files">
     
     <!-- Favicon -->
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📝</text></svg>">
     
     <style>
         /* CSS Custom Properties - Dark Theme Design System */
@@ -544,7 +544,7 @@
                         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.94-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/>
                     </svg>
                 </div>
-                <h1 class="sidebar-title">VaultGPT</h1>
+                <h1 class="sidebar-title">ChatGPT→MD</h1>
             </div>
             
             <nav>
@@ -588,8 +588,8 @@
         <header class="main-header">
             <div class="header-content">
                 <div>
-                    <h1 class="header-title">ChatGPT to Obsidian Converter</h1>
-                    <p class="header-subtitle">Transform your conversations into organized Markdown files</p>
+                    <h1 class="header-title">ChatGPT to Markdown Converter</h1>
+                    <p class="header-subtitle">Transform your conversations into clean Markdown files</p>
                 </div>
                 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatgpt-cursor-import",
   "version": "1.0.0",
-  "description": "Convert ChatGPT conversation exports to Obsidian-friendly Markdown files",
+  "description": "Convert ChatGPT conversation exports to clean Markdown files",
   "main": "index.html",
   "scripts": {
     "start": "kill-port 5173 && vite",
@@ -17,7 +17,6 @@
   },
   "keywords": [
     "chatgpt",
-    "obsidian",
     "markdown",
     "converter",
     "export",

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 /**
  * Main Application Entry Point
- * Initializes the ChatGPT to Obsidian converter with clean architecture
+ * Initializes the ChatGPT to Markdown converter with clean architecture
  * Following AGENTS.md principle: clean separation of concerns and initialization
  */
 

--- a/src/modules/applicationOrchestrator.js
+++ b/src/modules/applicationOrchestrator.js
@@ -1,6 +1,6 @@
 /**
  * Application Orchestrator
- * Main coordinator for the ChatGPT to Obsidian converter application
+ * Main coordinator for the ChatGPT to Markdown converter application
  * Following AGENTS.md principle: clean architecture with separated concerns
  */
 
@@ -20,7 +20,7 @@ import {
 import { ERROR_MESSAGES, STATUS_MESSAGES } from '../utils/constants.js';
 
 /**
- * ChatGPT to Obsidian Application
+ * ChatGPT to Markdown Application
  * WHY: Orchestrates the entire conversion workflow with proper error handling
  */
 export class ChatGPTConverter {
@@ -48,7 +48,7 @@ export class ChatGPTConverter {
             // Set up file upload handling
             this.fileUploader.setFileSelectedCallback(this.handleFileUpload.bind(this));
             
-            console.log('✅ ChatGPT to Obsidian Converter initialized');
+            console.log('✅ ChatGPT to Markdown Converter initialized');
             console.log(`📁 File System Access API: ${isFileSystemAccessSupported() ? 'Available' : 'Not available'}`);
             
         } catch (error) {
@@ -171,28 +171,7 @@ export class ChatGPTConverter {
         }
     }
 
-    /**
-     * Handle simplified directory selection
-     * WHY: Provides fallback option when main picker fails
-     */
-    async handleSimpleDirectorySelection() {
-        try {
-            const directoryHandle = await selectDirectory({});
-            this.selectedDirectoryHandle = directoryHandle;
-            
-            this.showSuccess(`✅ Selected directory: ${directoryHandle.name}. Ready to save files!`);
-            this.updateSaveButtonState();
-            
-            // Re-render the files table to show Save buttons
-            if (this.allFiles && this.allFiles.length > 0) {
-                this.renderFilesTable();
-            }
-            
-        } catch (error) {
-            console.error('Simple directory selection error:', error);
-            this.showError(error.message);
-        }
-    }
+
 
     /**
      * Save files to local directory
@@ -309,12 +288,12 @@ export class ChatGPTConverter {
     }
 
     /**
-     * Save individual file to Obsidian directory
+     * Save individual file to chosen directory
      * WHY: Reuses the same File System Access API logic as bulk save for consistency
      * 
      * @param {Object} file - File object to save
      */
-    async saveSingleFileToObsidian(file) {
+    async saveSingleFileToMarkdown(file) {
         try {
             // Check if File System Access API is supported
             if (!isFileSystemAccessSupported()) {
@@ -890,7 +869,7 @@ export class ChatGPTConverter {
                 };
                 
                 // Use the dedicated individual file save method
-                await this.saveSingleFileToObsidian(file);
+                await this.saveSingleFileToMarkdown(file);
             });
         });
     }
@@ -1047,10 +1026,8 @@ export class ChatGPTConverter {
             buttonGroup.style.marginBottom = 'var(--space-4)';
             
             const selectBtn = this.createDirectoryButton();
-            const simpleBtn = this.createSimpleDirectoryButton();
             
             buttonGroup.appendChild(selectBtn);
-            buttonGroup.appendChild(simpleBtn);
             content.appendChild(buttonGroup);
             
             // Instructions
@@ -1094,26 +1071,13 @@ export class ChatGPTConverter {
         btn.className = 'btn';
         btn.textContent = this.selectedDirectoryHandle ? 
             `📂 Change Directory (Current: ${this.selectedDirectoryHandle.name})` : 
-            '📂 Choose Obsidian Folder';
+            '📂 Choose Folder';
         btn.onclick = () => this.handleDirectorySelection();
         btn.style.marginRight = '10px';
         return btn;
     }
 
-    /**
-     * Create simple directory selection button
-     * WHY: Fallback for when main picker fails
-     */
-    createSimpleDirectoryButton() {
-        const btn = document.createElement('button');
-        btn.className = 'btn';
-        btn.textContent = '📁 Simple Folder Picker';
-        btn.onclick = () => this.handleSimpleDirectorySelection();
-        btn.style.marginRight = '10px';
-        btn.style.background = '#6c757d';
-        btn.title = 'Try this if the main folder picker doesn\'t work';
-        return btn;
-    }
+
 
     /**
      * Create save to local folder button
@@ -1157,7 +1121,7 @@ export class ChatGPTConverter {
             `;
         } else {
             instructions.innerHTML = `
-                <strong>Select your Obsidian vault folder</strong><br>
+                <strong>Select your destination folder</strong><br>
                 Choose where you want to save your converted Markdown files.
             `;
         }

--- a/src/modules/conversionEngine.js
+++ b/src/modules/conversionEngine.js
@@ -98,7 +98,7 @@ function extractMessageContent(message) {
 
 /**
  * Format message content as blockquotes while preserving line breaks
- * WHY: Obsidian blockquotes provide better visual distinction for message content
+ * WHY: Blockquotes provide better visual distinction for message content
  * 
  * @param {string} content - Raw message content
  * @returns {string} - Content formatted as blockquotes
@@ -117,7 +117,7 @@ function formatAsBlockquote(content) {
 
 /**
  * Convert a single conversation to Markdown format
- * WHY: Obsidian uses Markdown, so we need consistent formatting
+ * WHY: Markdown requires consistent formatting for proper rendering
  * 
  * @param {Object} conversation - ChatGPT conversation object
  * @returns {string} - Formatted Markdown content
@@ -129,7 +129,7 @@ export function convertConversationToMarkdown(conversation) {
     
     const messages = extractMessagesFromMapping(mapping);
     
-    // Build Markdown with Obsidian-optimized structure
+            // Build Markdown with clean structure
     // Format timestamp as YYYY-MM-DD, HH:mm:ss for consistency
     const timestamp = new Date(createTime * 1000);
     const formattedTimestamp = `${timestamp.getFullYear()}-${String(timestamp.getMonth() + 1).padStart(2, '0')}-${String(timestamp.getDate()).padStart(2, '0')}, ${String(timestamp.getHours()).padStart(2, '0')}:${String(timestamp.getMinutes()).padStart(2, '0')}:${String(timestamp.getSeconds()).padStart(2, '0')}`;
@@ -141,7 +141,7 @@ export function convertConversationToMarkdown(conversation) {
         ''
     ];
     
-    // Add formatted messages with clean Obsidian styling
+            // Add formatted messages with clean styling
     for (const message of messages) {
         const authorDisplay = message.author === 'user' 
             ? '**🧑‍💬 User**' 
@@ -178,7 +178,7 @@ export function processConversations(conversations, processedIds = new Set()) {
     // Sort chronologically for proper file creation order
     const sortedConversations = sortConversationsChronologically(conversations);
     console.log(`📅 Processing ${sortedConversations.length} conversations in chronological order (oldest first)`);
-    console.log(`🕐 This ensures newest conversations appear at top when sorted by creation date in Obsidian`);
+            console.log(`🕐 This ensures consistent chronological ordering of conversations`);
     
     const usedFilenames = [];
     

--- a/src/modules/fileSystemManager.js
+++ b/src/modules/fileSystemManager.js
@@ -585,7 +585,7 @@ async function showBulkDuplicateDialog(scanResults) {
 
 /**
  * Save multiple files with chronological timing and duplicate handling
- * WHY: Ensures files are created in chronological order for proper Obsidian sorting
+ * WHY: Ensures files are created in chronological order for proper organization
  * 
  * @param {Array} files - Array of file objects to save
  * @param {FileSystemDirectoryHandle} directoryHandle - Target directory
@@ -693,7 +693,7 @@ export async function saveFilesChronologically(files, directoryHandle, progressC
         }
     }
     
-    console.log(`📅 Files will be created oldest-first to maintain chronological order in Obsidian`);
+            console.log(`📅 Files will be created oldest-first to maintain chronological order`);
     
     // Now save the selected files
     let successCount = 0;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,6 @@
 /**
  * Application Constants
- * Centralized configuration values for the ChatGPT to Obsidian converter
+ * Centralized configuration values for the ChatGPT to Markdown converter
  */
 
 // File processing constants

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -82,7 +82,7 @@ export function isValidJsonFile(file) {
 
 /**
  * Sort conversations chronologically for proper file creation order
- * WHY: Oldest-first creation ensures newest appear at top in Obsidian date sort
+ * WHY: Oldest-first creation ensures consistent chronological ordering
  * 
  * @param {Array} conversations - Array of conversation objects
  * @returns {Array} - Sorted conversations (oldest first)

--- a/test-vite-react/package.json
+++ b/test-vite-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatgpt-converter-tests",
   "version": "1.0.0",
-  "description": "Test suite for ChatGPT to Obsidian Converter",
+  "description": "Test suite for ChatGPT to Markdown Converter",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",

--- a/test-vite-react/tests/integration/fullWorkflow.test.js
+++ b/test-vite-react/tests/integration/fullWorkflow.test.js
@@ -89,7 +89,7 @@ describe('Full Workflow Integration Tests', () => {
             // Verify file generation
             const firstFile = results.files[0];
             expect(firstFile.filename).toBe('Test Integration Workflow.md');
-            // Title no longer included in content (shown by Obsidian filename)
+            // Title no longer included in content (shown by filename)
             expect(firstFile.content).not.toContain('# Test Integration Workflow');
             expect(firstFile.content).toContain('**🧑‍💬 User**');
             // Verify markdown content structure and formatting
@@ -464,9 +464,9 @@ describe('Full Workflow Integration Tests', () => {
                 </div>
             `;
 
-            // Mock the ChatGPTConverter class with the saveSingleFileToObsidian method
+            // Mock the ChatGPTConverter class with the saveSingleFileToMarkdown method
             const mockConverter = {
-                saveSingleFileToObsidian: jest.fn().mockResolvedValue(true),
+                saveSingleFileToMarkdown: jest.fn().mockResolvedValue(true),
                 attachFileButtonHandlers: function() {
                     // Replicate the save button handler logic
                     document.querySelectorAll('.save-file-btn').forEach(btn => {
@@ -481,7 +481,7 @@ describe('Full Workflow Integration Tests', () => {
                                 title: title
                             };
                             
-                            await this.saveSingleFileToObsidian(file);
+                            await this.saveSingleFileToMarkdown(file);
                         });
                     });
                 }
@@ -495,7 +495,7 @@ describe('Full Workflow Integration Tests', () => {
             // Wait for async call and verify
             return new Promise(resolve => {
                 setTimeout(() => {
-                    expect(mockConverter.saveSingleFileToObsidian).toHaveBeenCalledWith({
+                    expect(mockConverter.saveSingleFileToMarkdown).toHaveBeenCalledWith({
                         filename: 'test-conversation.md',
                         content: 'test content',
                         title: 'Test Conversation'

--- a/test-vite-react/tests/setup.js
+++ b/test-vite-react/tests/setup.js
@@ -153,7 +153,7 @@ global.testMocks = {
 export const testMocks = global.testMocks;
 
 console.log('🧪 Test environment setup complete');
-console.log('📊 Running ChatGPT to Obsidian Converter tests...');
+    console.log('📊 Running ChatGPT to Markdown Converter tests...');
 
 // Global test configuration
 global.testConfig = {

--- a/test-vite-react/tests/unit/conversionEngine.test.js
+++ b/test-vite-react/tests/unit/conversionEngine.test.js
@@ -36,7 +36,7 @@ describe('Conversion Engine', () => {
 
             const result = convertConversationToMarkdown(conversation);
             
-            // Title no longer included in content (shown by Obsidian filename)
+            // Title no longer included in content (shown by filename)
             expect(result).not.toContain('# Test Conversation');
             expect(result).toContain('**🧑‍💬 User**');
             expect(result).toContain('Hello, how are you?');

--- a/tests/test_python_converter.py
+++ b/tests/test_python_converter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Python tests for ChatGPT to Obsidian Converter
+Python tests for ChatGPT to Markdown Converter
 Following AGENTS.md testing guidelines
 """
 
@@ -29,7 +29,7 @@ except ImportError:
 
 
 class TestChatGPTConverter(unittest.TestCase):
-    """Test suite for ChatGPT to Obsidian converter Python implementation"""
+    """Test suite for ChatGPT to Markdown converter Python implementation"""
 
     def setUp(self):
         """Set up test fixtures"""
@@ -184,12 +184,12 @@ class TestChatGPTConverter(unittest.TestCase):
         """Test conversation to markdown conversion"""
         markdown = convert_conversation_to_markdown(self.sample_conversation)
         
-        # Check structure
-        self.assertIn('# Python Best Practices', markdown)
+        # Check structure (title no longer included in content, shown by filename)
+        self.assertNotIn('# Python Best Practices', markdown)
         self.assertIn('**Created:**', markdown)
         self.assertIn('---', markdown)
-        self.assertIn('**User:**', markdown)
-        self.assertIn('**Assistant:**', markdown)
+        self.assertIn('**🧑‍💬 User**', markdown)
+        self.assertIn('**🤖 Assistant**', markdown)
         self.assertIn('What are Python best practices?', markdown)
 
     def test_convert_conversation_missing_title(self):
@@ -198,7 +198,7 @@ class TestChatGPTConverter(unittest.TestCase):
         del conversation['title']
         
         markdown = convert_conversation_to_markdown(conversation)
-        self.assertIn('# Untitled Conversation', markdown)
+        self.assertNotIn('# Untitled Conversation', markdown)
 
     def test_process_conversations(self):
         """Test processing multiple conversations"""
@@ -317,8 +317,8 @@ class TestChatGPTConverter(unittest.TestCase):
             self.assertTrue(filename.endswith('.md'))
             # No longer using date prefix - now human readable
             
-            # Verify markdown structure
-            self.assertIn('# ', markdown)
+            # Verify markdown structure (title no longer included in content)
+            self.assertNotIn('# ', markdown)
             self.assertIn('**Created:**', markdown)
             self.assertIn('---', markdown)
 


### PR DESCRIPTION
- Rebrand from 'VaultGPT - ChatGPT to Obsidian Converter' to 'ChatGPT to Markdown Converter'
- Remove Obsidian-specific references throughout codebase
- Remove non-functional 'Simple Folder Picker' button
- Update UI text to be generic and clean
- Update package.json and README.md descriptions
- Fix test expectations to match current behavior
- All tests passing (62 JS tests + 21 Python tests)

This makes the tool more broadly applicable for any markdown workflow, not just Obsidian, while maintaining all existing functionality.