### PR TITLE
Hide upload card during conversion progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,7 +651,7 @@
                     </div>
                 </div>
                 
-                <div class="card">
+                <div class="card" id="uploadCard">
                     <div class="card-header">
                         <h2 class="card-title">Upload Conversations</h2>
                         <p class="card-description">Select your ChatGPT conversations.json file to begin conversion</p>

--- a/src/components/ProgressDisplay.js
+++ b/src/components/ProgressDisplay.js
@@ -139,6 +139,15 @@ export class ProgressDisplay {
             }
         });
         
+        // Hide the upload card when showing progress (for conversion operations)
+        if (!switchToFilesView) {
+            const uploadCard = document.getElementById('uploadCard');
+            if (uploadCard) {
+                uploadCard.style.display = 'none';
+                logInfo('✅ Upload card hidden during conversion');
+            }
+        }
+        
         this.container.style.display = 'block';
         this.isVisible = true;
         
@@ -222,6 +231,13 @@ export class ProgressDisplay {
         if (conversionProgressCard) {
             conversionProgressCard.style.display = 'none';
             logInfo('✅ Conversion progress card hidden');
+        }
+        
+        // Show the upload card again when progress is hidden (for conversion operations)
+        const uploadCard = document.getElementById('uploadCard');
+        if (uploadCard) {
+            uploadCard.style.display = 'block';
+            logInfo('✅ Upload card shown again after conversion');
         }
     }
 

--- a/test-vite-react/tests/unit/progressDisplay.test.js
+++ b/test-vite-react/tests/unit/progressDisplay.test.js
@@ -10,6 +10,7 @@ import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globa
 document.body.innerHTML = `
     <div id="progressContainer"></div>
     <div id="progressCard" style="display: none;"></div>
+    <div id="uploadCard" style="display: block;"></div>
 `;
 
 // Mock the constants
@@ -34,6 +35,7 @@ describe('Progress Display Component', () => {
         // Reset DOM
         document.getElementById('progressContainer').innerHTML = '';
         document.getElementById('progressCard').style.display = 'none';
+        document.getElementById('uploadCard').style.display = 'block';
         
         // Reset mocks
         jest.clearAllMocks();
@@ -250,6 +252,38 @@ describe('Progress Display Component', () => {
             // Test value over 100
             progressDisplay.updateProgress(150, 'Over 100');
             expect(progressDisplay.progressFill.style.width).toBe('100%');
+        });
+
+        test('should hide upload card during conversion progress', () => {
+            const uploadCard = document.getElementById('uploadCard');
+            expect(uploadCard.style.display).toBe('block'); // Initially visible
+            
+            progressDisplay.initialize();
+            progressDisplay.show(false, false); // Conversion progress (not files view)
+            
+            expect(uploadCard.style.display).toBe('none'); // Should be hidden
+        });
+
+        test('should show upload card again when progress is hidden', () => {
+            const uploadCard = document.getElementById('uploadCard');
+            expect(uploadCard.style.display).toBe('block'); // Initially visible
+            
+            progressDisplay.initialize();
+            progressDisplay.show(false, false); // Conversion progress
+            expect(uploadCard.style.display).toBe('none'); // Hidden during progress
+            
+            progressDisplay.hide();
+            expect(uploadCard.style.display).toBe('block'); // Should be visible again
+        });
+
+        test('should not hide upload card during files view progress', () => {
+            const uploadCard = document.getElementById('uploadCard');
+            expect(uploadCard.style.display).toBe('block'); // Initially visible
+            
+            progressDisplay.initialize();
+            progressDisplay.show(true, true); // Files view progress
+            
+            expect(uploadCard.style.display).toBe('block'); // Should remain visible
         });
     });
 }); 


### PR DESCRIPTION
Fixes issue where upload section remained visible during conversion process. Upload card now hides during conversion and reappears when complete.