### PR TITLE
fix: optimize Vercel deployments to prevent duplicate builds

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,39 @@
+# Test files and directories
+tests/
+test-vite-react/
+*.test.js
+*.test.jsx
+*.spec.js
+*.spec.jsx
+
+# Development files
+.cursorrules
+.cursor.json
+LOGGING.md
+AGENTS.md
+
+# Python files (not needed for static deployment)
+*.py
+__pycache__/
+*.pyc
+
+# Development dependencies
+node_modules/
+
+# Build artifacts
+dist/
+build/
+
+# Logs and temporary files
+*.log
+temp-*/
+*.tmp
+*.temp
+
+# Git and IDE files
+.git/
+.vscode/
+.idea/
+
+# Environment files
+.env* 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "kill-port 5173 && vite",
     "dev": "kill-port 5173 && vite",
-    "build": "echo 'No build step required for static site'",
+    "build": "echo 'Static site - no build required' && exit 0",
     "deploy": "vercel --prod",
     "test": "cd test-vite-react && npm test",
     "test:install": "cd test-vite-react && npm install",

--- a/vercel.json
+++ b/vercel.json
@@ -44,5 +44,12 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
-  ]
+  ],
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "dev": false,
+      "preview": false
+    }
+  }
 } 


### PR DESCRIPTION
- Add .vercelignore to exclude test files, docs, and dev files from deployments
- Configure branch deployment rules in vercel.json to only deploy from main
- Fix build script to exit cleanly and prevent deployment retries
- Reduce unnecessary deployments triggered by irrelevant file changes