### PR TITLE
fix: hide duplicate download button on mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,6 +563,11 @@
                 padding: var(--space-4);
             }
 
+            /* Hide static download button on mobile - mobile-specific button will be shown instead */
+            .zip-download {
+                display: none;
+            }
+
             /* Improve table responsiveness on mobile */
             .file-table {
                 font-size: var(--font-size-sm);


### PR DESCRIPTION
## Problem

The mobile view was showing multiple 'Download All as ZIP' buttons:
1. Static HTML button (in results view)
2. Dynamic JavaScript button (mobile-specific)

This created confusion and poor UX on mobile devices.

## Solution

Added CSS rule to hide the static download button on mobile devices:

```css
/* Hide static download button on mobile - mobile-specific button will be shown instead */
.zip-download {
    display: none;
}
```

## Changes

- **index.html**: Added CSS rule in mobile media query to hide `.zip-download` class
- Mobile users now see only the mobile-specific download button with better styling
- Desktop users continue to see the original static button
- No functional changes to download functionality

## Testing

- ✅ Desktop: Static button still visible and functional
- ✅ Mobile: Only mobile-specific button visible
- ✅ Both buttons maintain their respective functionality

## Screenshots

Before: Mobile view showed two identical download buttons
After: Mobile view shows only one, well-designed download button

This fix improves the mobile user experience while maintaining full functionality for all users. 