### PR TITLE
feat(conversion): Obsidian-optimized Markdown (Reading mode friendly)

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -57,6 +57,23 @@ export function formatLondonHHmm(date) {
 }
 
 /**
+ * Format London time human-readable: h:mm am/pm (lowercase)
+ */
+export function formatLondonTimeHuman(date) {
+    const p = getLondonParts(date);
+    return `${p.hour12}:${String(p.minute).padStart(2, '0')} ${p.ampm}`;
+}
+
+/**
+ * Format London time for filenames: HH.mm (24-hour)
+ */
+export function formatLondonTimeFile(date) {
+    const tz = 'Europe/London';
+    const f = new Intl.DateTimeFormat('en-GB', { timeZone: tz, hour: '2-digit', minute: '2-digit', hour12: false });
+    return f.format(date).replace(':', '.');
+}
+
+/**
  * Format London created string for frontmatter: Monday, August 18th 2025, 1:23 pm
  */
 export function formatLondonCreatedHuman(date) {
@@ -72,10 +89,7 @@ export function buildObsidianFilename(conversation) {
     const timestampSec = conversation.create_time || 0;
     const date = new Date(timestampSec * 1000);
     const humanDate = formatLondonHumanDate(date);
-    const tz = 'Europe/London';
-    const hm = new Intl.DateTimeFormat('en-GB', { timeZone: tz, hour12: false, hour: '2-digit', minute: '2-digit' })
-        .format(date)
-        .replace(':', '.');
+    const hm = formatLondonTimeFile(date);
     const rawTitle = conversation.title || 'Untitled Conversation';
     const safeTitle = cleanFilename(rawTitle) || 'Untitled Conversation';
     const filename = `${safeTitle} — ${humanDate} — ${hm}.md`;
@@ -204,7 +218,7 @@ export function splitByCodeFences(content) {
 export function ensureClosedFences(markdown) {
     const count = (markdown.match(/```/g) || []).length;
     if (count % 2 === 1) {
-        return markdown + '\n```txt\n';
+        return markdown + '\n```\n';
     }
     return markdown;
 }

--- a/test-vite-react/tests/integration/fullWorkflow.test.js
+++ b/test-vite-react/tests/integration/fullWorkflow.test.js
@@ -92,10 +92,10 @@ describe('Full Workflow Integration Tests', () => {
             expect(firstFile.filename).toMatch(/.+ — [A-Za-z]+, [A-Za-z]+ \d{1,2}(st|nd|rd|th) \d{4} — \d{2}\.\d{2}\.md$/);
             // Title no longer included in content (shown by filename)
             expect(firstFile.content).not.toContain('# Test Integration Workflow');
-            expect(firstFile.content).toMatch(/> \[!note\] 🧑‍💬 User — (\d{2}:\d{2}|#\d+)/);
+            expect(firstFile.content).toMatch(/## 🧑‍💬 User — (\d{2}:\d{2}|#\d+)/);
             // Verify markdown content structure and formatting
             expect(firstFile.content).toContain('How do I test modular JavaScript?');
-            expect(firstFile.content).toMatch(/> \[!info\]- 🤖 Assistant — (\d{2}:\d{2}|#\d+)/);
+            expect(firstFile.content).toMatch(/## 🤖 Assistant — (\d{2}:\d{2}|#\d+)/);
             expect(firstFile.content).toContain('You can use Jest with ES modules');
             // Collapsible content should include both user and assistant messages
             expect(firstFile.content).toContain('What about testing file operations?');

--- a/test-vite-react/tests/unit/conversionEngine.test.js
+++ b/test-vite-react/tests/unit/conversionEngine.test.js
@@ -41,9 +41,9 @@ describe('Conversion Engine', () => {
             // Frontmatter present
             expect(result).toContain('---');
             expect(result).toContain('tags: [chatgpt]');
-            // Callout headers with role icons/labels
-            expect(result).toMatch(/> \[!note\] 🧑‍💬 User — (\d{2}:\d{2}|#1)/);
-            expect(result).toMatch(/> \[!info\]- 🤖 Assistant — (\d{2}:\d{2}|#2)/);
+            // Heading sections with role icons/labels
+            expect(result).toMatch(/## 🧑‍💬 User — (\d{2}:\d{2}|#1)/);
+            expect(result).toMatch(/## 🤖 Assistant — (\d{2}:\d{2}|#2)/);
             expect(result).toContain('Hello, how are you?');
             expect(result).toContain('I am doing well, thank you!');
         });
@@ -97,6 +97,7 @@ describe('Conversion Engine', () => {
             const result = convertConversationToMarkdown(conversation);
             // Title no longer included in content
             expect(result).toContain('created:');
+            expect(result).toContain('---');
             expect(result).not.toContain('<summary>🧑‍💬 User');
             expect(result).not.toContain('<summary>🤖 Assistant');
         });
@@ -166,8 +167,8 @@ describe('Conversion Engine', () => {
             };
 
             const result = convertConversationToMarkdown(conversation);
-            // Should only contain the text parts, not the garbled object strings
-            expect(result).toContain('This is text content and this continues the text with more text.');
+            // Should include image placeholders for non-text parts
+            expect(result).toContain('This is text content_Image omitted_ and this continues the text_Image omitted_ with more text.');
             // Should not contain the garbled citation text
             expect(result).not.toContain('citeturn');
             expect(result).not.toContain('[object Object]');
@@ -310,9 +311,9 @@ describe('Conversion Engine', () => {
             const result = convertConversationToMarkdown(conversation);
             expect(result).toContain('Valid message');
             expect(result).toContain('Another valid message');
-            // Should not render empty assistant message callout
-            const assistantCallouts = (result.match(/> \[!info\]- 🤖 Assistant/g) || []).length;
-            expect(assistantCallouts).toBe(0);
+            // Should not render empty assistant section
+            const assistantHeadings = (result.match(/## 🤖 Assistant/g) || []).length;
+            expect(assistantHeadings).toBe(0);
         });
     });
 
@@ -354,7 +355,7 @@ describe('Conversion Engine', () => {
             expect(file.conversationId).toBe('conv_1');
             expect(file.createTime).toBe(1703522622);
             expect(file.createdDate).toBe(new Date(1703522622 * 1000).toLocaleDateString());
-            expect(file.content).toMatch(/> \[!note\] 🧑‍💬 User — (\d{2}:\d{2}|#\d+)/);
+            expect(file.content).toMatch(/## 🧑‍💬 User — (\d{2}:\d{2}|#\d+)/);
             expect(file.content).toContain('Test message');
         });
 


### PR DESCRIPTION
- Render messages as foldable headings instead of callouts/details\n- Minimal frontmatter: created (London), tags [chatgpt], url from id\n- Human-friendly filename: <Title> — <HumanDate> — <HH.mm>.md (London)\n- Per-message timestamps from create_time with HH:mm; fallback #n\n- Cleanup pipeline on text only: linkify, whitespace, smart punctuation\n- Auto-close code fences; preserve code blocks\n- Insert '_Image omitted_' for non-text parts\n- Add London time helpers; update tests to match